### PR TITLE
Suggested fix for bug#19269.

### DIFF
--- a/Src/C/run-time/eif_internal.h
+++ b/Src/C/run-time/eif_internal.h
@@ -111,7 +111,7 @@ rt_private rt_inline EIF_BOOLEAN eif_is_special_type (EIF_INTEGER dftype)
 	/* Does `dtype' represent a SPECIAL [XX] where XX can be a basic type
 	 * or a reference type? */
 {
-	EIF_TYPE_INDEX dtype = To_dtype(dftype);
+	EIF_TYPE_INDEX dtype = To_dtype(eif_decoded_type(dftype).id);
 	return EIF_TEST(
 		(dtype == egc_sp_bool) ||
 		(dtype == egc_sp_char) ||
@@ -133,9 +133,9 @@ rt_private rt_inline EIF_BOOLEAN eif_is_special_type (EIF_INTEGER dftype)
 
 #define ei_special(obj)	(EIF_TEST((HEADER(obj)->ov_flags & (EO_SPEC | EO_TUPLE)) == EO_SPEC))
 #define ei_tuple(obj)	(EIF_TEST((HEADER(obj)->ov_flags & (EO_SPEC | EO_TUPLE)) == (EO_SPEC | EO_TUPLE)))
-#define eif_is_tuple_type(dftype) (EIF_TEST(To_dtype(dftype) == egc_tup_dtype))
+#define eif_is_tuple_type(dftype) (EIF_TEST(To_dtype(eif_decoded_type(dftype).id) == egc_tup_dtype))
 
-#define eif_special_any_type(dftype) (EIF_TEST((uint32) To_dtype(dftype) == (uint32) egc_sp_ref))
+#define eif_special_any_type(dftype) (EIF_TEST((uint32) To_dtype(eif_decoded_type(dftype).id) == (uint32) egc_sp_ref))
 
 #ifdef WORKBENCH
 #define	ei_offset(i,object)		(EIF_INTEGER) ((EIF_REFERENCE) ei_oref(i, (EIF_REFERENCE) (object)) - (EIF_REFERENCE) (object))


### PR DESCRIPTION
**bug#19269:**

The following calls:

   l_reflector: REFLECTOR
   ...
   l_reflector.is_special_any_type (({SPECIAL [ANY]}).type_id)
   l_reflector.is_special_type (({SPECIAL [ANY]}).type_id)
   l_reflector.is_tuple_type (({TUPLE}).type_id)

return False when compiled in void-safe mode. The following calls return the expected result:

   l_reflector.is_special_any_type (({detachable SPECIAL [ANY]}).type_id)
   l_reflector.is_special_type (({detachable SPECIAL [ANY]}).type_id)
   l_reflector.is_tuple_type (({detachable TUPLE}).type_id)
