### PR TITLE
Fixed external routines (C flag -DWIN32_LEAN_AND_MEAN)

### DIFF
--- a/Src/library/com/Interfaces/ecom_enum_statstg.e
+++ b/Src/library/com/Interfaces/ecom_enum_statstg.e
@@ -166,42 +166,42 @@ feature {NONE} -- Externals
 
 	c_next_item (a_item: POINTER; a_res: POINTER; a_count: TYPED_POINTER [NATURAL_32]): NATURAL_32
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"((IEnumSTATSTG*)$a_item)->lpVtbl->Next ((IEnumSTATSTG*)$a_item, 1, (STATSTG*)$a_res, (ULONG*)$a_count)"
 		end
 
 	c_skip (a_item: POINTER; n: NATURAL_32)
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
-			"((IEnumSTATSTG*)$a_item)->lpVtbl->Skip ((IEnumSTATSTG*)$a_item, (ULONG)$n)"
+			"((IEnumSTATSTG*)$a_item)->lpVtbl->Skip ((IEnumSTATSTG*)$a_item, (ULONG)$n);"
 		end
 
 	c_reset (a_item: POINTER)
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
-			"((IEnumSTATSTG*)$a_item)->lpVtbl->Reset((IEnumSTATSTG*)$a_item)"
+			"((IEnumSTATSTG*)$a_item)->lpVtbl->Reset((IEnumSTATSTG*)$a_item);"
 		end
 
 	c_clone (a_item, a_res: POINTER)
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
-			"((IEnumSTATSTG*)$a_item)->lpVtbl->Clone ((IEnumSTATSTG*)$a_item, (IEnumSTATSTG**)$a_res)"
+			"((IEnumSTATSTG*)$a_item)->lpVtbl->Clone ((IEnumSTATSTG*)$a_item, (IEnumSTATSTG**)$a_res);"
 		end
 
 	c_release (a_item: POINTER)
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
-			"((IEnumSTATSTG*)$a_item)->lpVtbl->Release((IEnumSTATSTG*)$a_item)"
+			"((IEnumSTATSTG*)$a_item)->lpVtbl->Release((IEnumSTATSTG*)$a_item);"
 		end
 
 	c_sizeof_statstg: INTEGER
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"sizeof(STATSTG)"
 		end

--- a/Src/library/com/Structures/ecom_statstg.e
+++ b/Src/library/com/Structures/ecom_statstg.e
@@ -140,15 +140,15 @@ feature {NONE} -- Externals
 	c_co_task_mem_free (a_item: like item)
 			-- Call `CoTaskMemFree' on `a_item'.
 		external
-			"C inline use <windows.h>"
+			"C inline use <objbase.h>"
 		alias
-			"CoTaskMemFree((void*)$a_item)"
+			"CoTaskMemFree((void*)$a_item);"
 		end
 
 	c_name (a_item: like item): POINTER
 			-- Retrieve `pwcsName' field of STATSTG structure
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"((STATSTG*)$a_item)->pwcsName"
 		end
@@ -156,7 +156,7 @@ feature {NONE} -- Externals
 	c_size (a_item: like item): POINTER
 			-- Retrieve pointer on `cbSize' field of STATSTG structure
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"&(((STATSTG*)$a_item)->cbSize)"
 		end
@@ -164,7 +164,7 @@ feature {NONE} -- Externals
 	c_type (a_item: like item): INTEGER
 			-- Retrieve `type' field of STATSTG structure
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"(EIF_INTEGER)((STATSTG*)$a_item)->type"
 		end
@@ -172,7 +172,7 @@ feature {NONE} -- Externals
 	c_modification_time (a_item: like item): POINTER
 			-- Retrieve pointer on `mtime' field of STATSTG structure
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"&(((STATSTG*)$a_item)->mtime)"
 		end
@@ -180,7 +180,7 @@ feature {NONE} -- Externals
 	c_creation_time (a_item: like item): POINTER
 			-- Retrieve pointer on `ctime' field of STATSTG structure
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"&(((STATSTG*)$a_item)->ctime)"
 		end
@@ -188,7 +188,7 @@ feature {NONE} -- Externals
 	c_access_time (a_item: like item): POINTER
 			-- Retrieve pointer on `atime' field of STATSTG structure
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"&(((STATSTG*)$a_item)->atime)"
 		end
@@ -196,7 +196,7 @@ feature {NONE} -- Externals
 	c_mode (a_item: like item): INTEGER
 			-- Retrieve `grfMode' field of STATSTG structure
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"(EIF_INTEGER)((STATSTG*)$a_item)->grfMode"
 		end
@@ -204,7 +204,7 @@ feature {NONE} -- Externals
 	c_locks_supported (a_item: like item): INTEGER
 			-- Retrieve `grfMode' field of STATSTG structure
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"(EIF_INTEGER)(((STATSTG*)$a_item)->grfLocksSupported)"
 		end
@@ -212,7 +212,7 @@ feature {NONE} -- Externals
 	c_clsid (a_item: like item): POINTER
 			-- Retrieve pointer on `clsid' field of STATSTG structure
 		external
-			"C inline use <windows.h>"
+			"C inline use <objidl.h>"
 		alias
 			"&(((STATSTG*)$a_item)->clsid)"
 		end


### PR DESCRIPTION
Fixed external routines due to the use of the C flag -DWIN32_LEAN_AND_MEAN.
See bug#19357.