### PR TITLE
EiffelStudio once creation procedure update.

### DIFF
--- a/Src/Eiffel/API/error/eiffel/feature/vgcc10.e
+++ b/Src/Eiffel/API/error/eiffel/feature/vgcc10.e
@@ -1,0 +1,104 @@
+note
+	description: "Object representing an error, generic classes can't have once creation procedures"
+	date: "$Date$"
+	revision: "$Revision$"
+
+class
+	VGCC10
+inherit
+
+	VGCC
+		redefine
+			subcode,
+			print_short_help,
+			trace_single_line,
+			build_explain
+		end
+
+create
+	make_invalid_context
+
+feature {NONE} -- Implementation
+
+	make_invalid_context (a_feature: FEATURE_I; a_context_class, a_written_class: CLASS_C)
+			-- New instance of VRVA(2) error.
+		require
+			a_feature_attached: a_feature /= Void
+			a_context_class_attached: a_context_class /= Void
+			a_written_class_attached: a_written_class /= Void
+		do
+			set_class (a_context_class)
+			set_written_class (a_written_class)
+			set_feature (a_feature)
+		end
+
+
+feature -- Properties
+
+	subcode: INTEGER = 10
+
+feature -- Output
+
+	build_explain (a_text_formatter: TEXT_FORMATTER)
+			-- Construct `a_text_formatter' with error.
+		do
+		end
+
+feature {NONE} -- Output
+
+	print_short_help (t: TEXT_FORMATTER)
+			-- <Precursor>
+		do
+			t.add_new_line
+			format_elements (t, locale.translation_in_context ("[
+						Generic class cannot have a once procedure {1}.
+						What to do: either make the class non-generic, or do not use once creation procedures..
+					]", "compiler.error"),
+				<<agent e_feature.append_name>>)
+			t.add_new_line
+			t.add_new_line
+		end
+
+	trace_single_line (t: TEXT_FORMATTER)
+			-- <Precursor>
+		do
+			format_elements (t, locale.translation_in_context
+				("Generic class cannot have a once procedure {1}.", "compiler.error"),
+				<<agent e_feature.append_name>>)
+		end
+
+
+
+note
+	copyright:	"Copyright (c) 1984-2018, Eiffel Software"
+	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
+	licensing_options:	"http://www.eiffel.com/licensing"
+	copying: "[
+			This file is part of Eiffel Software's Eiffel Development Environment.
+			
+			Eiffel Software's Eiffel Development Environment is free
+			software; you can redistribute it and/or modify it under
+			the terms of the GNU General Public License as published
+			by the Free Software Foundation, version 2 of the License
+			(available at the URL listed under "license" above).
+			
+			Eiffel Software's Eiffel Development Environment is
+			distributed in the hope that it will be useful, but
+			WITHOUT ANY WARRANTY; without even the implied warranty
+			of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+			See the GNU General Public License for more details.
+			
+			You should have received a copy of the GNU General Public
+			License along with Eiffel Software's Eiffel Development
+			Environment; if not, write to the Free Software Foundation,
+			Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+		]"
+	source: "[
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
+		]"
+
+end

--- a/Src/Eiffel/API/error/eiffel/feature/vgcc9.e
+++ b/Src/Eiffel/API/error/eiffel/feature/vgcc9.e
@@ -1,0 +1,106 @@
+note
+	description: "Error for a declaration of a once feature as a creation procedure"
+	date: "$Date$"
+	revision: "$Revision$"
+
+class
+	VGCC9
+
+inherit
+
+	VGCC
+		redefine
+			subcode,
+			print_short_help,
+			trace_single_line,
+			build_explain
+
+		end
+
+create
+	make_invalid_context
+
+feature {NONE} -- Implementation
+
+	make_invalid_context (a_feature: FEATURE_I; a_context_class, a_written_class: CLASS_C)
+			-- New instance of VRVA(2) error.
+		require
+			a_feature_attached: a_feature /= Void
+			a_context_class_attached: a_context_class /= Void
+			a_written_class_attached: a_written_class /= Void
+		do
+			set_class (a_context_class)
+			set_written_class (a_written_class)
+			set_feature (a_feature)
+		end
+
+
+feature -- Properties
+
+	subcode: INTEGER = 9
+
+feature -- Output
+
+	build_explain (a_text_formatter: TEXT_FORMATTER)
+			-- Construct `a_text_formatter' with error.
+		do
+		end
+
+
+feature {NONE} -- Output
+
+	print_short_help (t: TEXT_FORMATTER)
+			-- <Precursor>
+		do
+			t.add_new_line
+			format_elements (t, locale.translation_in_context ("[
+						Once creation procedure {1} is inherited from {2} but must be immediate (non-inherited).
+						What to do:It may not be used in a Call (qualified or not) (i.e., only in a creation all).
+					]", "compiler.error"),
+				<<agent e_feature.append_name, agent written_class.append_name>>)
+			t.add_new_line
+			t.add_new_line
+		end
+
+	trace_single_line (t: TEXT_FORMATTER)
+			-- <Precursor>
+		do
+			format_elements (t, locale.translation_in_context
+				("Once creation procedure {1} is inherited from {2} but must be immediate (non-inherited).", "compiler.error"),
+				<<agent e_feature.append_name, agent written_class.append_name>>)
+		end
+
+
+note
+	copyright:	"Copyright (c) 1984-2018, Eiffel Software"
+	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
+	licensing_options:	"http://www.eiffel.com/licensing"
+	copying: "[
+			This file is part of Eiffel Software's Eiffel Development Environment.
+			
+			Eiffel Software's Eiffel Development Environment is free
+			software; you can redistribute it and/or modify it under
+			the terms of the GNU General Public License as published
+			by the Free Software Foundation, version 2 of the License
+			(available at the URL listed under "license" above).
+			
+			Eiffel Software's Eiffel Development Environment is
+			distributed in the hope that it will be useful, but
+			WITHOUT ANY WARRANTY; without even the implied warranty
+			of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+			See the GNU General Public License for more details.
+			
+			You should have received a copy of the GNU General Public
+			License along with Eiffel Software's Eiffel Development
+			Environment; if not, write to the Free Software Foundation,
+			Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+		]"
+	source: "[
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
+		]"
+
+end -- class VAPE

--- a/Src/Eiffel/API/error/eiffel/feature/vuex2.e
+++ b/Src/Eiffel/API/error/eiffel/feature/vuex2.e
@@ -1,0 +1,111 @@
+note
+	description: "Error for a feature call (qualified or not )of once creation procedure, only valid in a creation call"
+	date: "$Date$"
+	revision: "$Revision$"
+
+class
+	VUEX2
+
+
+inherit
+
+	FEATURE_ERROR
+		redefine
+			print_short_help,
+			trace_single_line,
+			subcode
+		end
+
+create
+	make
+
+feature {NONE} -- Creation
+
+	make (t: FEATURE_I; f: FEATURE_I; c: CLASS_C; w: detachable CLASS_C; l: LOCATION_AS)
+			-- Create an error for a  call to a feature `t` in feature `f` of class `c` in the code from class `w` at location `l`.
+		require
+			t_attached: attached t
+			f_attached: attached f
+			c_attached: attached c
+			l_attached: attached l
+		do
+			class_c := c
+			written_class := if attached w then w else f.written_class end
+			set_feature (f)
+			set_location (l)
+			callee := t.e_feature
+		ensure
+			callee_set: attached callee
+			class_c_set: class_c = c
+			written_class_set: attached written_class and (attached w implies written_class = w)
+			feature_set: attached e_feature
+			line_set: line = l.line
+			column_set: column = l.column
+		end
+
+
+	code: STRING = "VUEX"
+
+	subcode: INTEGER = 3;
+
+feature {NONE} -- Access
+
+	callee: E_FEATURE
+			-- A feature of the call.
+
+feature {NONE} -- Output
+
+	print_short_help (t: TEXT_FORMATTER)
+			-- <Precursor>
+		do
+			t.add_new_line
+			format_elements (t, locale.translation_in_context ("[
+						{1} used in a feature call.
+						
+						What to do:It may not be used in a Call (qualified or not) (i.e., only in a creation all).
+					]", "compiler.error"),
+				<<agent callee.append_name>>)
+			t.add_new_line
+			t.add_new_line
+		end
+
+	trace_single_line (t: TEXT_FORMATTER)
+			-- <Precursor>
+		do
+			format_elements (t, locale.translation_in_context
+				("Feature {1} may not be used in a Call (qualified or not) (i.e., only in a creation all).", "compiler.error"),
+				<<agent callee.append_name>>)
+		end
+
+note
+	copyright: "Copyright (c) 1984-2018, Eiffel Software"
+	license: "GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
+	licensing_options: "http://www.eiffel.com/licensing"
+	copying: "[
+			This file is part of Eiffel Software's Eiffel Development Environment.
+			
+			Eiffel Software's Eiffel Development Environment is free
+			software; you can redistribute it and/or modify it under
+			the terms of the GNU General Public License as published
+			by the Free Software Foundation, version 2 of the License
+			(available at the URL listed under "license" above).
+			
+			Eiffel Software's Eiffel Development Environment is
+			distributed in the hope that it will be useful, but
+			WITHOUT ANY WARRANTY; without even the implied warranty
+			of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+			See the GNU General Public License for more details.
+			
+			You should have received a copy of the GNU General Public
+			License along with Eiffel Software's Eiffel Development
+			Environment; if not, write to the Free Software Foundation,
+			Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+		]"
+	source: "[
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
+		]"
+end

--- a/Src/Eiffel/eiffel/AST/visitor/ast_feature_checker_generator.e
+++ b/Src/Eiffel/eiffel/AST/visitor/ast_feature_checker_generator.e
@@ -1597,6 +1597,13 @@ feature {NONE} -- Implementation
 									has_vucr := w /= error_handler.warning_level
 								end
 							end
+						elseif
+							l_found_feature.is_once and then attached l_found_feature.written_class.creators as l_found_creators and then l_found_creators.has (l_found_feature.feature_name) and then
+							attached context.current_class.creators as l_creators and then not l_creators.has (current_feature.feature_name) then
+								-- l_found_feature is a once creation procedure
+								-- It may not be used in a Call (qualified or not) (i.e., only in a creation all).
+							error_handler.insert_error (create {VUEX2}.make (l_feature, current_feature,  context.current_class, context.written_class, a_name))
+							reset_types
 						end
 						if attached old_assigner_source then
 								-- Check if the assigner query is obsolete.

--- a/Src/Eiffel/eiffel/byte_code/assign_bl.e
+++ b/Src/Eiffel/eiffel/byte_code/assign_bl.e
@@ -173,6 +173,18 @@ feature
 			expr_b: EXPR_B
 			saved_context: like context
 		do
+				-- If the source is a creation_exp_b and it's a once creation procedure
+				-- Analize it as a instance free call.
+			if
+				is_creation_instruction and then attached {CREATION_EXPR_B} source as l_source and then
+				attached {FEATURE_B} l_source.call as l_featureb and then l_featureb.is_once
+			then
+				l_featureb.set_precursor_type (l_source.info.type_to_create.actual_type)
+				l_featureb.enable_instance_free
+				l_featureb.set_type (l_source.info.type_to_create.actual_type)
+				set_source (l_source.call)
+			end
+
 			target_type := context.real_type (target.type)
 
 				-- The target is always expanded in-line for de-referencing.
@@ -417,7 +429,9 @@ feature
 				-- simple expression.
 				-- Note that this does not mean the target was predefined
 				-- (e.g. with a Result := "string").
-			if not (target_propagated and source.stored_register = target) then
+			if attached {FEATURE_BW} source as l_source and then l_source.is_instance_free then
+				-- Do nothing.	
+			elseif not (target_propagated and source.stored_register = target) then
 				generate_normal_assignment (how)
 			end
 		end

--- a/Src/Eiffel/eiffel/byte_code/call_access_b.e
+++ b/Src/Eiffel/eiffel/byte_code/call_access_b.e
@@ -456,6 +456,9 @@ feature {NONE} -- C code generation
 				buf.put_string_literal (feature_name)
 				buf.put_two_character (',', ' ')
 				t.print_register
+			elseif attached {FEATURE_B} Current as l_current and then l_current.is_once and then call_kind_creation = call_kind then
+					-- The current feature is a once creation procedure, we use the return type as a instance free call.
+				buf.put_static_type_id (cl_type_i.static_type_id (context.context_class_type.type))
 			else
 				buf.put_string ({C_CONST}.dtype)
 				buf.put_character ('(')
@@ -618,7 +621,7 @@ feature {NONE} -- Implementation
 		end
 
 note
-	copyright:	"Copyright (c) 1984-2017, Eiffel Software"
+	copyright:	"Copyright (c) 1984-2018, Eiffel Software"
 	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options:	"http://www.eiffel.com/licensing"
 	copying: "[

--- a/Src/Eiffel/eiffel/byte_code/feature_b.e
+++ b/Src/Eiffel/eiffel/byte_code/feature_b.e
@@ -260,6 +260,14 @@ feature {NONE} -- Array optimization
 			Result := System.remover.array_optimizer
 		end
 
+feature -- Once creation procedure
+
+	enable_instance_free
+			-- Set current routine as instance free in the context of Once creation procedure
+		do
+			is_instance_free := True
+		end
+
 feature -- Inlining
 
 	inlined_byte_code: ACCESS_B
@@ -598,7 +606,7 @@ feature {NONE} -- Normalization of types
 		end
 
 note
-	copyright:	"Copyright (c) 1984-2017, Eiffel Software"
+	copyright:	"Copyright (c) 1984-2018, Eiffel Software"
 	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options:	"http://www.eiffel.com/licensing"
 	copying: "[

--- a/Src/Eiffel/eiffel/interface/feature_i.e
+++ b/Src/Eiffel/eiffel/interface/feature_i.e
@@ -2313,6 +2313,16 @@ feature -- Signature checking
 				then
 					error_handler.insert_error (create {VRVA}.make_invalid_type (Current, a_context_class, written_class, l_type))
 				end
+					-- A generic class can't have a once creation procedure
+				if is_once and then a_context_class.is_generic then
+					error_handler.insert_error (create {VGCC10}.make_invalid_context (Current, a_context_class, written_class))
+				end
+			else
+					-- For an inherited once feature, we check if it's part of the creations procedures.
+					-- In that case we raise an issue since once creation procedures must be immediates (not inherited)
+				if is_once and then	attached a_context_class.creators as l_creators and then l_creators.has (Current.feature_name) then
+					error_handler.insert_error (create {VGCC9}.make_invalid_context (Current, a_context_class, written_class))
+				end
 			end
 
 				-- For an inherited attributem we make sure that it is not inherited in a user defined
@@ -3392,12 +3402,43 @@ feature -- C code generation
 			l_byte_code: BYTE_CODE
 			tmp_body_index: INTEGER
 			l_byte_context: like byte_context
+			l_assign: ASSIGN_B
+			l_compound: BYTE_LIST [BYTE_NODE]
 		do
 			if used then
 				tmp_body_index := body_index
 				l_byte_code := tmp_opt_byte_server.disk_item (tmp_body_index)
 				if l_byte_code = Void then
 					l_byte_code := byte_server.disk_item (tmp_body_index)
+				end
+
+					-- If the current feature is a once creation procedure
+					-- We generate the creation procedure as a function.
+				if
+					Current.is_once and then
+					attached class_type.associated_class.creators as l_creators and then
+					l_creators.has (Current.feature_name)
+				then
+						-- Generate the C once factory function for once creation procedures
+					create l_assign
+					l_assign.set_target (create {RESULT_B})
+					l_assign.set_source (create {CURRENT_B})
+					create l_compound.make (l_byte_code.compound.count + 1)
+
+					from
+						l_byte_code.compound.start
+					until
+						l_byte_code.compound.off
+					loop
+						l_compound.force (l_byte_code.compound.item_for_iteration)
+						l_byte_code.compound.forth
+					end
+					l_compound.force (l_assign)
+
+					if attached {ONCE_BYTE_CODE} l_byte_code as l_once_byte_code then
+						l_once_byte_code.set_compound (l_compound)
+					end
+					l_byte_code.set_result_type (class_type.associated_class.actual_type)
 				end
 
 				prepare_object_relative_once (l_byte_code)


### PR DESCRIPTION
Added new validity rules for once creation procedure (classes VGCC10, VGCC9, and VUEX2)
Updated code to generate once creation procedure as functions
Updated code to handle once creation procedures calls as instance free calls.