### PR TITLE
Modifications necessary to compile with the Gobo compiler

### DIFF
--- a/Src/Eiffel/API/evaluated_type/like_type_a.e
+++ b/Src/Eiffel/API/evaluated_type/like_type_a.e
@@ -432,7 +432,7 @@ feature -- Modification
 
 	set_is_implicitly_attached
 		local
-			t: TYPE_A
+			t: like actual_type
 		do
 				-- Make sure `actual_type' does not affect attachment status.
 			t := actual_type
@@ -445,7 +445,7 @@ feature -- Modification
 
 	unset_is_implicitly_attached
 		local
-			t: TYPE_A
+			t: like actual_type
 		do
 				-- Make sure `actual_type' does not affect attachment status.
 			t := actual_type
@@ -687,7 +687,7 @@ feature {TYPE_A} -- Helpers
 		end
 
 note
-	copyright:	"Copyright (c) 1984-2017, Eiffel Software"
+	copyright:	"Copyright (c) 1984-2018, Eiffel Software"
 	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options:	"http://www.eiffel.com/licensing"
 	copying: "[

--- a/Src/Eiffel/API/query_language/ql_criterion/ql_argument_criterion/ql_argument_not_criterion.e
+++ b/Src/Eiffel/API/query_language/ql_criterion/ql_argument_criterion/ql_argument_not_criterion.e
@@ -27,8 +27,7 @@ inherit
 			require_compiled
 		redefine
 			wrapped_criterion,
-			intrinsic_domain,
-			item_type
+			intrinsic_domain
 		end
 
 create
@@ -54,7 +53,7 @@ feature -- Access
 		end
 
 note
-	copyright: "Copyright (c) 1984-2013, Eiffel Software"
+	copyright: "Copyright (c) 1984-2018, Eiffel Software"
 	license: "GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options: "http://www.eiffel.com/licensing"
 	copying: "[

--- a/Src/Eiffel/API/query_language/ql_criterion/ql_argument_criterion/ql_argument_or_criterion.e
+++ b/Src/Eiffel/API/query_language/ql_criterion/ql_argument_criterion/ql_argument_or_criterion.e
@@ -26,8 +26,7 @@ inherit
 		redefine
 			left,
 			right,
-			intrinsic_domain,
-			item_type
+			intrinsic_domain
 		end
 
 create

--- a/Src/Eiffel/Ace/ec_kernel.ecf
+++ b/Src/Eiffel/Ace/ec_kernel.ecf
@@ -22,12 +22,12 @@
 				<platform excluded_value="windows"/>
 			</condition>
 		</external_include>
-		<external_include location="\$(EIFFEL_SRC)\C\bench">
+		<external_include location="$(EIFFEL_SRC)\C\bench">
 			<condition>
 				<platform value="windows"/>
 			</condition>
 		</external_include>
-		<external_include location="\$(EIFFEL_SRC)\C\platform">
+		<external_include location="$(EIFFEL_SRC)\C\platform">
 			<condition>
 				<platform value="windows"/>
 			</condition>

--- a/Src/Eiffel/eiffel/AST/skeleton/formal_constraint_as.e
+++ b/Src/Eiffel/eiffel/AST/skeleton/formal_constraint_as.e
@@ -33,7 +33,7 @@ inherit
 
 	SHARED_ERROR_HANDLER
 		export
-			{NONE} all
+			{ANY} error_handler
 		end
 
 	COMPILER_EXPORTER

--- a/Src/Eiffel/eiffel/byte_code/external_bl.e
+++ b/Src/Eiffel/eiffel/byte_code/external_bl.e
@@ -27,8 +27,7 @@ inherit
 			generate_access,
 			generate_end,
 			generate_on,
-			parent,
-			set_register
+			parent
 		end
 
 	ROUTINE_BL
@@ -476,7 +475,7 @@ feature {NONE} -- Status report
 		end
 
 note
-	copyright:	"Copyright (c) 1984-2017, Eiffel Software"
+	copyright:	"Copyright (c) 1984-2018, Eiffel Software"
 	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options:	"http://www.eiffel.com/licensing"
 	copying: "[

--- a/Src/Eiffel/eiffel/compiler/feature_dependance.e
+++ b/Src/Eiffel/eiffel/compiler/feature_dependance.e
@@ -14,7 +14,8 @@ inherit
 			{FEATURE_DEPENDANCE} all
 			{ANY} cursor, go_to, start, before, after, forth, item, active,
 				count, first_element, last_element, object_comparison, sublist,
-				extend, prunable, off, readable, valid_cursor, extendible
+				extend, prunable, off, readable, valid_cursor, extendible,
+				new_cursor
 		redefine
 			make, wipe_out, copy, is_equal
 		end
@@ -217,7 +218,7 @@ feature -- Debug
 		end;
 
 note
-	copyright:	"Copyright (c) 1984-2010, Eiffel Software"
+	copyright:	"Copyright (c) 1984-2018, Eiffel Software"
 	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options:	"http://www.eiffel.com/licensing"
 	copying: "[

--- a/Src/library/uuid/uuid_generator.e
+++ b/Src/library/uuid/uuid_generator.e
@@ -1,4 +1,4 @@
-﻿note
+note
 	description: "[
 		Generates uuids according to RFC 4122, Variant 1 0, Version 4.
 	]"
@@ -98,6 +98,8 @@ feature {NONE} -- Implementation
 			l_seed := l_seed + l_date.millisecond_now.to_natural_64
 				-- Use RFC 4122 trick to preserve as much meaning of `l_seed' onto an INTEGER_32.
 			Result := (l_seed |>> 32).bit_xor (l_seed).as_integer_32 & 0x7FFFFFFF
+		ensure
+			instance_free: class
 		end
 
 note

--- a/Src/tools/compliance_checker/ace/ecchecker.ecf
+++ b/Src/tools/compliance_checker/ace/ecchecker.ecf
@@ -10,6 +10,9 @@
 		<option warning="true">
 			<assertions/>
 		</option>
+		<capability>
+			<concurrency support="none"/>
+		</capability>
 		<setting name="cls_compliant" value="True"/>
 		<setting name="console_application" value="False"/>
 		<setting name="dead_code_removal" value="True"/>


### PR DESCRIPTION
[EADP] ECF C:\DriveE\ise\git\Src\tools\compliance_checker\ace\ecchecker.ecf (26,130): value 'scoop' for capability 'concurrency' not supported by library 'assembly_resolver'.
        Used in ECF C:\DriveE\ise\git\Src\dotnet\consumer\consumer.ecf (37,111)
        Used in ECF C:\DriveE\ise\git\Src\Eiffel\Ace\ec.ecf (27,96)
[VDRS-4] class QL_ARGUMENT_NOT_CRITERION (31,4): Redefine subclause of QL_NOT_CRITERION lists feature `item_type` but it is not redefined.
[VDRS-4] class QL_ARGUMENT_OR_CRITERION (30,4): Redefine subclause of QL_OR_CRITERION lists feature `item_type` but it is not redefined.
[VDRS-4] class EXTERNAL_BL (31,4): Redefine subclause of EXTERNAL_B lists feature `set_register` but it is not redefined.
[VAPE] class FORMAL_CONSTRAINT_AS (438,28): feature `error_handler` of class FORMAL_CONSTRAINT_AS appearing in the precondition of `check_constraint_creation` is not exported to class ANY to which feature `check_constraint_creation` is exported.
[VUEX-2] class E_FEATURE (664,14): feature `new_cursor` of class FEATURE_DEPENDANCE is not exported to class E_FEATURE.
[VUEX-2] class E_FEATURE (714,14): feature `new_cursor` of class FEATURE_DEPENDANCE is not exported to class E_FEATURE.
[VUEX-2] class E_FEATURE (811,14): feature `new_cursor` of class FEATURE_DEPENDANCE is not exported to class E_FEATURE.
[VUEX-2] class E_FEATURE (860,14): feature `new_cursor` of class FEATURE_DEPENDANCE is not exported to class E_FEATURE.
[VUCR] class UUID_GENERATOR (47,18): static feature contains an unqualified call to non-static feature `seed`.
[VUCR] class UUID_GENERATOR (67,35): static feature contains an unqualified call to non-static feature `seed`.