### PR TITLE
FILE_NAME  marked as obsolete because it does not support Unicode

### DIFF
--- a/Src/library/base/elks/kernel/file.e
+++ b/Src/library/base/elks/kernel/file.e
@@ -183,21 +183,21 @@ feature -- Initialization
 		end
 
 	make_temporary_open_with_prefix (a_prefix: READABLE_STRING_GENERAL)
-			-- Create a file object with a unique temporary file name with prefix `a_prefix',
+			-- Create a file object with a unique temporary file name with prefix `a_prefix`,
 			-- with read/write mode.
+		note
+			EIS:"name=mkstemp", "src=ttp://man7.org/linux/man-pages/man3/mkstemp.3.html", "protocol=uri"
 		local
 			l_temp: C_STRING
-			l_res: INTEGER
+			l_fd: INTEGER
 			l_ptr: POINTER
 			l_file_info: FILE_INFO
 			s: STRING
 		do
-				-- UX platforms
-				-- http://man7.org/linux/man-pages/man3/mkstemp.3.html
 			create l_temp.make (a_prefix + "XXXXXX")
-			l_res := eif_temp_file (l_temp.item)
+			l_fd := eif_temp_file (l_temp.item)
 			make_with_name (l_temp.string)
-			fd_open_read_write (l_res)
+			fd_open_read_write (l_fd)
 		ensure
 			exists: exists
 			open_read: is_open_read
@@ -2128,7 +2128,7 @@ feature {NONE} -- Implementation
 
 	eif_temp_file (a_name_template: POINTER): INTEGER
 			-- Create a unique temporary file name and return a file descriptor.
-			--| UX platforms: The `mkstemp()' function generates a unique temporary filename from
+			--| UX platforms: The `mkstemp()` function generates a unique temporary filename from
        		--|	template, creates and opens the file, and returns an open file descriptor for the file.
 		note
 			EIS: "name=Creates a unique temporary file", "src=http://man7.org/linux/man-pages/man3/mkstemp.3.html", "protocol=uri"
@@ -2144,99 +2144,95 @@ feature {NONE} -- Implementation
 				#define EINVAL 22 /* Invalid argument  */
 				#define EEXIST 17 /* File exists */
 
-				static const char letters[] =
-				"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+				static const char letters[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
 				/* Generate a temporary file name based on TMPL.  TMPL must match the
-				   rules for mk[s]temp (i.e. end in "XXXXXX").  The name constructed
-				   does not exist at the time of the call to mkstemp.  TMPL is
-				   overwritten with the result.  */
-				  int len;
-				  char *tmpl;
-				  char *XXXXXX;
-				  tmpl = $a_name_template;
-				  static unsigned long long value;
-				  unsigned long long random_time_bits;
-				  unsigned int count;
-				  int fd = -1;
-				  int save_errno = errno;
+				rules for mk[s]temp (i.e. end in "XXXXXX").  The name constructed
+				does not exist at the time of the call to mkstemp.  TMPL is
+				overwritten with the result.  */
+				int len;
+				char *tmpl;
+				char *XXXXXX;
+				tmpl = $a_name_template;
+				static unsigned long long value;
+				unsigned long long random_time_bits;
+				unsigned int count;
+				int fd = -1;
+				int save_errno = errno;
 
-				    /* A lower bound on the number of temporary files to attempt to
-				     generate.  The maximum total number of temporary file names that
-				     can exist for a given template is 62**6.  It should never be
-				     necessary to try all these combinations.  Instead if a reasonable
-				     number of names is tried (we define reasonable as 62**3) fail to
-				     give the system administrator the chance to remove the problems.  */
-				  #define ATTEMPTS_MIN (62 * 62 * 62)
+				/* A lower bound on the number of temporary files to attempt to
+				generate.  The maximum total number of temporary file names that
+				can exist for a given template is 62**6.  It should never be
+				necessary to try all these combinations.  Instead if a reasonable
+				number of names is tried (we define reasonable as 62**3) fail to
+				give the system administrator the chance to remove the problems.  */
+				#define ATTEMPTS_MIN (62 * 62 * 62)
 
-				  /* The number of times to attempt to generate a temporary file.  To
-				     conform to POSIX, this must be no smaller than TMP_MAX.  */
+				/* The number of times to attempt to generate a temporary file.  To
+				conform to POSIX, this must be no smaller than TMP_MAX.  */
 				#if ATTEMPTS_MIN < TMP_MAX
-				  unsigned int attempts = TMP_MAX;
+					unsigned int attempts = TMP_MAX;
 				#else
-				  unsigned int attempts = ATTEMPTS_MIN;
+					unsigned int attempts = ATTEMPTS_MIN;
 				#endif
 
-				  len = strlen (tmpl);
-				  if (len < 6 || strcmp (&tmpl[len - 6], "XXXXXX")){
-				      errno = EINVAL;
-				      return -1;
-				  }
+				len = strlen (tmpl);
+				if (len < 6 || strcmp (&tmpl[len - 6], "XXXXXX")){
+					errno = EINVAL;
+					return -1;
+				}
 
-				  /* This is where the Xs start.  */
-				  XXXXXX = &tmpl[len - 6];
+				/* This is where the Xs start.  */
+				XXXXXX = &tmpl[len - 6];
 
-				  /* Get some more or less random data.  */
-				  {
-				  SYSTEMTIME    stNow;
-				  FILETIME ftNow;
+				/* Get some more or less random data.  */
+				{
+					SYSTEMTIME    stNow;
+					FILETIME ftNow;
 
-				  // get system time
-				  GetSystemTime(&stNow);
-				  stNow.wMilliseconds = 500;
-				  if (!SystemTimeToFileTime(&stNow, &ftNow))  {
-				    errno = -1;
-				    return -1;
-				  }
-
-				    random_time_bits = (((unsigned long long)ftNow.dwHighDateTime << 32)
+					// get system time
+					GetSystemTime(&stNow);
+					stNow.wMilliseconds = 500;
+					if (!SystemTimeToFileTime(&stNow, &ftNow))  {
+						errno = -1;
+						return -1;
+					}
+					random_time_bits = (((unsigned long long)ftNow.dwHighDateTime << 32)
 				                        | (unsigned long long)ftNow.dwLowDateTime);
-				  }
-				  value += random_time_bits ^ (unsigned long long)GetCurrentThreadId ();
+				}
+				value += random_time_bits ^ (unsigned long long)GetCurrentThreadId ();
 
-				  for (count = 0; count < attempts; value += 7777, ++count) {
-				      unsigned long long v = value;
+				for (count = 0; count < attempts; value += 7777, ++count) {
+					unsigned long long v = value;
 
-				      /* Fill in the random bits.  */
-				      XXXXXX[0] = letters[v % 62];
-				      v /= 62;
-				      XXXXXX[1] = letters[v % 62];
-				      v /= 62;
-				      XXXXXX[2] = letters[v % 62];
-				      v /= 62;
-				      XXXXXX[3] = letters[v % 62];
-				      v /= 62;
-				      XXXXXX[4] = letters[v % 62];
-				      v /= 62;
-				      XXXXXX[5] = letters[v % 62];
+					/* Fill in the random bits.  */
+					XXXXXX[0] = letters[v % 62];
+					v /= 62;
+					XXXXXX[1] = letters[v % 62];
+					v /= 62;
+					XXXXXX[2] = letters[v % 62];
+					v /= 62;
+					XXXXXX[3] = letters[v % 62];
+					v /= 62;
+					XXXXXX[4] = letters[v % 62];
+					v /= 62;
+					XXXXXX[5] = letters[v % 62];
 
-				      fd = open (tmpl, O_RDWR | O_CREAT | O_EXCL | O_BINARY, _S_IREAD | _S_IWRITE);
-				      if (fd >= 0)  {
-				     errno = save_errno;
-				     return fd;
+					fd = open (tmpl, O_RDWR | O_CREAT | O_EXCL | O_BINARY, _S_IREAD | _S_IWRITE);
+					if (fd >= 0)  {
+						errno = save_errno;
+						return fd;
+					} else if (errno != EEXIST){
+						return -1;
 				    }
-				      else if (errno != EEXIST){
-				    return -1;
-				    }
-				    }
-
-				  /* We got out of the loop because we ran out of combinations to try.  */
-				  errno = EEXIST;
-				  return -1;
-				#endif // _MSC_VER
-			#else
-				return mkstemp ($a_name_template);
-			#endif
+				}
+				/* We got out of the loop because we ran out of combinations to try.  */
+				errno = EEXIST;
+				return -1;
+			#endif // _MSC_VER
+		#else
+			return mkstemp ($a_name_template);
+		#endif
 			]"
 		end
 

--- a/Src/library/base/elks/kernel/file.e
+++ b/Src/library/base/elks/kernel/file.e
@@ -171,6 +171,39 @@ feature -- Initialization
 			open_append: is_open_append
 		end
 
+	make_temporary_open
+			-- Create a file object with a unique temporary file name,
+			-- with read/write mode.
+		do
+			make_temporary_open_with_prefix("tfn")
+		ensure
+			exists: exists
+			open_read: is_open_read
+			open_append: is_open_write
+		end
+
+	make_temporary_open_with_prefix (a_prefix: READABLE_STRING_GENERAL)
+			-- Create a file object with a unique temporary file name with prefix `a_prefix',
+			-- with read/write mode.
+		local
+			l_temp: C_STRING
+			l_res: INTEGER
+			l_ptr: POINTER
+			l_file_info: FILE_INFO
+			s: STRING
+		do
+				-- UX platforms
+				-- http://man7.org/linux/man-pages/man3/mkstemp.3.html
+			create l_temp.make (a_prefix + "XXXXXX")
+			l_res := eif_temp_file (l_temp.item)
+			make_with_name (l_temp.string)
+			fd_open_read_write (l_res)
+		ensure
+			exists: exists
+			open_read: is_open_read
+			open_append: is_open_write
+		end
+
 feature -- Access
 
 	path: PATH
@@ -2091,6 +2124,120 @@ feature {NONE} -- Implementation
 			"C signature (EIF_FILENAME): EIF_INTEGER use %"eif_file.h%""
 		alias
 			"eif_file_access_date"
+		end
+
+	eif_temp_file (a_name_template: POINTER): INTEGER
+			-- Create a unique temporary file name and return a file descriptor.
+			--| UX platforms: The `mkstemp()' function generates a unique temporary filename from
+       		--|	template, creates and opens the file, and returns an open file descriptor for the file.
+		note
+			EIS: "name=Creates a unique temporary file", "src=http://man7.org/linux/man-pages/man3/mkstemp.3.html", "protocol=uri"
+		external
+			"C inline use %"eif_file.h%""
+		alias
+			"[
+			#ifdef EIF_WINDOWS
+				#include <fcntl.h>
+				#ifdef _MSC_VER
+				#define open _open
+				#define close _close
+				#define EINVAL 22 /* Invalid argument  */
+				#define EEXIST 17 /* File exists */
+
+				static const char letters[] =
+				"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+				/* Generate a temporary file name based on TMPL.  TMPL must match the
+				   rules for mk[s]temp (i.e. end in "XXXXXX").  The name constructed
+				   does not exist at the time of the call to mkstemp.  TMPL is
+				   overwritten with the result.  */
+				  int len;
+				  char *tmpl;
+				  char *XXXXXX;
+				  tmpl = $a_name_template;
+				  static unsigned long long value;
+				  unsigned long long random_time_bits;
+				  unsigned int count;
+				  int fd = -1;
+				  int save_errno = errno;
+
+				    /* A lower bound on the number of temporary files to attempt to
+				     generate.  The maximum total number of temporary file names that
+				     can exist for a given template is 62**6.  It should never be
+				     necessary to try all these combinations.  Instead if a reasonable
+				     number of names is tried (we define reasonable as 62**3) fail to
+				     give the system administrator the chance to remove the problems.  */
+				  #define ATTEMPTS_MIN (62 * 62 * 62)
+
+				  /* The number of times to attempt to generate a temporary file.  To
+				     conform to POSIX, this must be no smaller than TMP_MAX.  */
+				#if ATTEMPTS_MIN < TMP_MAX
+				  unsigned int attempts = TMP_MAX;
+				#else
+				  unsigned int attempts = ATTEMPTS_MIN;
+				#endif
+
+				  len = strlen (tmpl);
+				  if (len < 6 || strcmp (&tmpl[len - 6], "XXXXXX")){
+				      errno = EINVAL;
+				      return -1;
+				  }
+
+				  /* This is where the Xs start.  */
+				  XXXXXX = &tmpl[len - 6];
+
+				  /* Get some more or less random data.  */
+				  {
+				  SYSTEMTIME    stNow;
+				  FILETIME ftNow;
+
+				  // get system time
+				  GetSystemTime(&stNow);
+				  stNow.wMilliseconds = 500;
+				  if (!SystemTimeToFileTime(&stNow, &ftNow))  {
+				    errno = -1;
+				    return -1;
+				  }
+
+				    random_time_bits = (((unsigned long long)ftNow.dwHighDateTime << 32)
+				                        | (unsigned long long)ftNow.dwLowDateTime);
+				  }
+				  value += random_time_bits ^ (unsigned long long)GetCurrentThreadId ();
+
+				  for (count = 0; count < attempts; value += 7777, ++count) {
+				      unsigned long long v = value;
+
+				      /* Fill in the random bits.  */
+				      XXXXXX[0] = letters[v % 62];
+				      v /= 62;
+				      XXXXXX[1] = letters[v % 62];
+				      v /= 62;
+				      XXXXXX[2] = letters[v % 62];
+				      v /= 62;
+				      XXXXXX[3] = letters[v % 62];
+				      v /= 62;
+				      XXXXXX[4] = letters[v % 62];
+				      v /= 62;
+				      XXXXXX[5] = letters[v % 62];
+
+				      fd = open (tmpl, O_RDWR | O_CREAT | O_EXCL | O_BINARY, _S_IREAD | _S_IWRITE);
+				      if (fd >= 0)  {
+				     errno = save_errno;
+				     return fd;
+				    }
+				      else if (errno != EEXIST){
+				    return -1;
+				    }
+				    }
+
+				  /* We got out of the loop because we ran out of combinations to try.  */
+				  errno = EEXIST;
+				  return -1;
+				#endif // _MSC_VER
+			#else
+				return mkstemp ($a_name_template);
+			#endif
+			]"
 		end
 
 feature {NONE} -- Inapplicable

--- a/Src/library/base/elks/kernel/file_name.e
+++ b/Src/library/base/elks/kernel/file_name.e
@@ -9,6 +9,8 @@ note
 class
 	FILE_NAME
 
+obsolete "This class is obsolete, use PATH instead"
+
 inherit
 	PATH_NAME
 
@@ -24,6 +26,11 @@ feature {NONE} -- Initialization
 
 	make_temporary_name
 			-- Create a temporary filename.
+		note
+				EIS:"name={FILE}.make_temporary_open", "src=eiffel:?class=FILE&feature=make_temporary_open","protocol=uri"
+				EIS:"name={FILE}.make_temporary_open_with_prefix", "src=eiffel:?class=FILE&feature=make_temporary_open_with_prefix","protocol=uri"
+		obsolete
+				"Use `{FILE}.make_temporary_open or {FILE}.make_temporary_open_with_prefix' instead. [2019-05-31]"
 		local
 			p: POINTER
 		do
@@ -133,7 +140,7 @@ feature {NONE} -- Externals
 		end
 
 note
-	copyright: "Copyright (c) 1984-2012, Eiffel Software and others"
+	copyright: "Copyright (c) 1984-2018, Eiffel Software and others"
 	license:   "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/Src/library/base/elks/kernel/file_name.e
+++ b/Src/library/base/elks/kernel/file_name.e
@@ -9,7 +9,7 @@ note
 class
 	FILE_NAME
 
-obsolete "This class is obsolete, use PATH instead"
+obsolete "This class is obsolete, use PATH instead [2019-05-31]"
 
 inherit
 	PATH_NAME
@@ -27,10 +27,10 @@ feature {NONE} -- Initialization
 	make_temporary_name
 			-- Create a temporary filename.
 		note
-				EIS:"name={FILE}.make_temporary_open", "src=eiffel:?class=FILE&feature=make_temporary_open","protocol=uri"
-				EIS:"name={FILE}.make_temporary_open_with_prefix", "src=eiffel:?class=FILE&feature=make_temporary_open_with_prefix","protocol=uri"
+			EIS:"name={FILE}.make_temporary_open", "src=eiffel:?class=FILE&feature=make_temporary_open","protocol=uri"
+			EIS:"name={FILE}.make_temporary_open_with_prefix", "src=eiffel:?class=FILE&feature=make_temporary_open_with_prefix","protocol=uri"
 		obsolete
-				"Use `{FILE}.make_temporary_open or {FILE}.make_temporary_open_with_prefix' instead. [2019-05-31]"
+			"Use `{FILE}.make_temporary_open or {FILE}.make_temporary_open_with_prefix` instead. [2019-05-31]"
 		local
 			p: POINTER
 		do

--- a/Src/library/base/elks/kernel/plain_text_file.e
+++ b/Src/library/base/elks/kernel/plain_text_file.e
@@ -20,7 +20,8 @@ create
 	make, make_with_name, make_with_path,
 	make_open_read, make_open_write, make_open_append,
 	make_open_read_write, make_create_read_write,
-	make_open_read_append
+	make_open_read_append,
+	make_temporary_open, make_temporary_open_with_prefix
 
 feature -- Status report
 
@@ -308,7 +309,7 @@ invariant
 	plain_text: is_plain_text
 
 note
-	copyright: "Copyright (c) 1984-2017, Eiffel Software and others"
+	copyright: "Copyright (c) 1984-2018, Eiffel Software and others"
 	license:   "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/Src/library/base/elks/kernel/plain_text_file.e
+++ b/Src/library/base/elks/kernel/plain_text_file.e
@@ -21,7 +21,7 @@ create
 	make_open_read, make_open_write, make_open_append,
 	make_open_read_write, make_create_read_write,
 	make_open_read_append,
-	make_temporary_open, make_temporary_open_with_prefix
+	make_open_temporary, make_open_temporary_with_prefix
 
 feature -- Status report
 

--- a/Src/library/base/elks/kernel/raw_file.e
+++ b/Src/library/base/elks/kernel/raw_file.e
@@ -20,7 +20,8 @@ create
 	make, make_with_name, make_with_path,
 	make_open_read, make_open_write, make_open_append,
 	make_open_read_write, make_create_read_write,
-	make_open_read_append
+	make_open_read_append,
+	make_temporary_open, make_temporary_open_with_prefix
 
 feature -- Status report
 

--- a/Src/library/base/elks/kernel/raw_file.e
+++ b/Src/library/base/elks/kernel/raw_file.e
@@ -21,7 +21,7 @@ create
 	make_open_read, make_open_write, make_open_append,
 	make_open_read_write, make_create_read_write,
 	make_open_read_append,
-	make_temporary_open, make_temporary_open_with_prefix
+	make_open_temporary, make_open_temporary_with_prefix
 
 feature -- Status report
 

--- a/Src/library/base/ise/kernel/dotnet/file.e
+++ b/Src/library/base/ise/kernel/dotnet/file.e
@@ -165,14 +165,31 @@ feature -- Initialization
 			open_append: is_open_append
 		end
 
-	make_temporary_open
+	make_open_temporary
 			-- Create a file object with a unique temporary file name,
 			-- with read/write mode.
 		local
-			l_temp: STRING
+			l_temp: STRING_32
 		do
 			create l_temp.make_from_cil ({SYSTEM_PATH}.get_temp_file_name)
 			create last_string.make_empty
+			set_name (l_temp)
+			open_read_write
+		ensure
+			exists: exists
+			open_read: is_open_read
+			open_write: is_open_write
+		end
+
+	make_open_temporary_with_prefix (a_prefix: READABLE_STRING_GENERAL)
+			-- Create a file object with a unique temporary file name with prefix `a_prefix`,
+			-- with read/write mode.
+		local
+			l_temp: STRING_32
+		do
+			create l_temp.make_from_cil ({SYSTEM_PATH}.get_temp_file_name)
+			create last_string.make_empty
+			l_temp.prepend (a_prefix.to_string_32)
 			set_name (l_temp)
 			open_read_write
 		ensure

--- a/Src/library/base/ise/kernel/dotnet/file.e
+++ b/Src/library/base/ise/kernel/dotnet/file.e
@@ -165,6 +165,22 @@ feature -- Initialization
 			open_append: is_open_append
 		end
 
+	make_temporary_open
+			-- Create a file object with a unique temporary file name,
+			-- with read/write mode.
+		local
+			l_temp: STRING
+		do
+			create l_temp.make_from_cil ({SYSTEM_PATH}.get_temp_file_name)
+			create last_string.make_empty
+			set_name (l_temp)
+			open_read_write
+		ensure
+			exists: exists
+			open_read: is_open_read
+			open_write: is_open_write
+		end
+
 feature -- Access
 
 	path: PATH

--- a/Src/library/base/ise/kernel/dotnet/plain_text_file.e
+++ b/Src/library/base/ise/kernel/dotnet/plain_text_file.e
@@ -25,7 +25,8 @@ create
 	make_with_name, make_open_read, make_open_write, make_open_append,
 	make_open_read_write, make_create_read_write,
 	make_open_read_append,
-	make_temporary_open
+	make_open_temporary,
+	make_open_temporary_with_prefix
 
 feature -- Status report
 

--- a/Src/library/base/ise/kernel/dotnet/plain_text_file.e
+++ b/Src/library/base/ise/kernel/dotnet/plain_text_file.e
@@ -24,7 +24,8 @@ create
 	make, make_with_path,
 	make_with_name, make_open_read, make_open_write, make_open_append,
 	make_open_read_write, make_create_read_write,
-	make_open_read_append
+	make_open_read_append,
+	make_temporary_open
 
 feature -- Status report
 
@@ -382,7 +383,7 @@ invariant
 
 note
 	library:	"EiffelBase: Library of reusable components for Eiffel."
-	copyright:	"Copyright (c) 1984-2012, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2018, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/Src/library/base/ise/kernel/dotnet/raw_file.e
+++ b/Src/library/base/ise/kernel/dotnet/raw_file.e
@@ -26,7 +26,8 @@ create
 	make, make_with_path,
 	make_with_name, make_open_read, make_open_write, make_open_append,
 	make_open_read_write, make_create_read_write,
-	make_open_read_append
+	make_open_read_append,
+	make_temporary_open
 
 feature -- Status report
 
@@ -371,7 +372,7 @@ invariant
 
 note
 	library:	"EiffelBase: Library of reusable components for Eiffel."
-	copyright:	"Copyright (c) 1984-2017, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2018, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/Src/library/base/ise/kernel/dotnet/raw_file.e
+++ b/Src/library/base/ise/kernel/dotnet/raw_file.e
@@ -27,7 +27,8 @@ create
 	make_with_name, make_open_read, make_open_write, make_open_append,
 	make_open_read_write, make_create_read_write,
 	make_open_read_append,
-	make_temporary_open
+	make_open_temporary,
+	make_open_temporary_with_prefix
 
 feature -- Status report
 


### PR DESCRIPTION
and  PATH should be used instead.
Added new creations procedures make_temporary_open and
make_temporary_open_with_prefixshould be added to the class  FILE  to create and open a temporary file