### PR TITLE
Updated EiffelBase classes `ISE_RUNTIME`, `REFLECTOR` and `REFLECTED_…

### DIFF
--- a/Src/C/run-time/eif_built_in.h
+++ b/Src/C/run-time/eif_built_in.h
@@ -88,7 +88,16 @@ extern "C" {
 #define eif_builtin_IDENTIFIED_ROUTINES_eif_current_object_id(object)	eif_reference_id(object)
 #define eif_builtin_IDENTIFIED_ROUTINES_eif_is_object_id_of_current(object,id) EIF_TEST(eif_id_object(id) == object)
 
-#define eif_builtin_REFLECTOR_c_set_dynamic_type(obj,enc_ftype)		eif_set_dynamic_type(obj,enc_ftype)
+/* REFLECTOR class */
+#define eif_builtin_REFLECTOR_c_set_dynamic_type(obj,enc_ftype)			eif_set_dynamic_type(obj,enc_ftype)
+#define eif_builtin_REFLECTOR_c_new_type_instance_of(type_id)			eif_type_malloc(eif_decoded_type(type_id), 0)
+#define eif_builtin_REFLECTOR_c_new_tuple_instance_of(type_id)			RTLNT(eif_decoded_type(type_id).id)
+#define eif_builtin_REFLECTOR_c_new_instance_of(type_id)			RTLNSMART(eif_decoded_type(type_id).id)
+#define eif_builtin_REFLECTOR_field_count_of_type(type_id)			ei_count_field_of_type(type_id)
+#define eif_builtin_REFLECTOR_field_count_of_type(type_id)			ei_count_field_of_type(type_id)
+#define eif_builtin_REFLECTOR_is_tuple_type(type_id)				eif_is_tuple_type(type_id)
+#define eif_builtin_REFLECTOR_is_special_type(type_id)				eif_is_special_type(type_id)
+#define eif_builtin_REFLECTOR_is_special_any_type(type_id)			eif_special_any_type(type_id)
 
 /* ISE_RUNTIME class */
 /* Define helper to avoid code duplication. */
@@ -193,8 +202,23 @@ rt_private rt_inline EIF_BOOLEAN rt_is_special_copy_semantics_item (EIF_INTEGER_
 #define eif_builtin_ISE_RUNTIME_set_integer_64_field_at(field_offs,obj,offs,val)	*(EIF_INTEGER_64 *) (eif_obj_at(obj,offs) + field_offs) = (EIF_INTEGER_64) (val)
 #define eif_builtin_ISE_RUNTIME_set_real_32_field_at(field_offs,obj,offs,val)		*(EIF_REAL_32 *) (eif_obj_at(obj,offs) + field_offs) = (EIF_REAL_32) (val)
 #define eif_builtin_ISE_RUNTIME_set_real_64_field_at(field_offs,obj,offs,val)		*(EIF_REAL_64 *) (eif_obj_at(obj,offs) + field_offs) = (EIF_REAL_64) (val)
-#define eif_builtin_ISE_RUNTIME_set_pointer_field_at(field_offs,obj,offs,val)			*(EIF_POINTER *) (eif_obj_at(obj,offs) + field_offs) = (EIF_POINTER) (val)
+#define eif_builtin_ISE_RUNTIME_set_pointer_field_at(field_offs,obj,offs,val)		*(EIF_POINTER *) (eif_obj_at(obj,offs) + field_offs) = (EIF_POINTER) (val)
 
+#define eif_builtin_ISE_RUNTIME_unlock_marking							eif_unlock_marking
+#define eif_builtin_ISE_RUNTIME_lock_marking							eif_lock_marking
+#define eif_builtin_ISE_RUNTIME_eif_gen_param_id(a_type_id, i)			eif_gen_param_id(a_type_id, i)
+#define eif_builtin_ISE_RUNTIME_generic_parameter_count(a_type_id)		eif_gen_count_with_dftype(eif_decoded_type(a_type_id).id)
+#define eif_builtin_ISE_RUNTIME_field_offset_of_type(i,a_type_id)		ei_offset_of_type(i,a_type_id)
+#define eif_builtin_ISE_RUNTIME_field_count_of_type(a_type_id)			ei_count_field_of_type(a_type_id)
+#define eif_builtin_ISE_RUNTIME_compiler_version						egc_compiler_tag
+
+#define eif_builtin_ISE_RUNTIME_persistent_field_count_of_type(a_type_id)	(System(To_dtype(eif_decoded_type(a_type_id).id)).cn_persistent_nbattr)
+#define eif_builtin_ISE_RUNTIME_is_field_expanded_of_type(i,a_type_id)		((System(To_dtype(eif_decoded_type(a_type_id).id)).cn_types[i - 1] & SK_HEAD) == SK_EXP)
+#define eif_builtin_ISE_RUNTIME_is_field_transient_of_type(i,a_type_id)		EIF_IS_TRANSIENT_ATTRIBUTE(System(To_dtype(eif_decoded_type(a_type_id).id)), i - 1)
+#define eif_builtin_ISE_RUNTIME_attached_type(a_type_id)					eif_attached_type(a_type_id)
+#define eif_builtin_ISE_RUNTIME_detachable_type(a_type_id)					eif_non_attached_type(a_type_id)
+#define eif_builtin_ISE_RUNTIME_is_attached_type(a_type_id)					eif_is_attached_type(a_type_id)
+#define eif_builtin_ISE_RUNTIME_type_conforms_to(a_type_id_1, a_type_id_2)	eif_gen_conf(a_type_id_1, a_type_id_2)
 
 /* MEMORY class */
 #define eif_builtin_MEMORY_free(obj)					eif_mem_free(obj)
@@ -302,6 +326,10 @@ rt_private rt_inline EIF_BOOLEAN rt_is_special_copy_semantics_item (EIF_INTEGER_
 #define eif_builtin_EQA_EXTERNALS_override_byte_code_of_body(body_id, pattern_id, byte_code, length)
 #endif
 
+
+/*REFLECTED_COPY_SEMANTICS_OBJECT class*/
+#define eif_builtin_REFLECTED_COPY_SEMANTICS_OBJECT_dereference(ptr, offset)	*(EIF_REFERENCE *) eif_obj_at(ptr, offset)
+#define eif_builtin_REFLECTED_COPY_SEMANTICS_OBJECT_object_from_address(ptr)	(EIF_REFERENCE) ptr
 
 #ifdef __cplusplus
 }

--- a/Src/C/run-time/eif_built_in.h
+++ b/Src/C/run-time/eif_built_in.h
@@ -94,7 +94,6 @@ extern "C" {
 #define eif_builtin_REFLECTOR_c_new_tuple_instance_of(type_id)			RTLNT(eif_decoded_type(type_id).id)
 #define eif_builtin_REFLECTOR_c_new_instance_of(type_id)			RTLNSMART(eif_decoded_type(type_id).id)
 #define eif_builtin_REFLECTOR_field_count_of_type(type_id)			ei_count_field_of_type(type_id)
-#define eif_builtin_REFLECTOR_field_count_of_type(type_id)			ei_count_field_of_type(type_id)
 #define eif_builtin_REFLECTOR_is_tuple_type(type_id)				eif_is_tuple_type(type_id)
 #define eif_builtin_REFLECTOR_is_special_type(type_id)				eif_is_special_type(type_id)
 #define eif_builtin_REFLECTOR_is_special_any_type(type_id)			eif_special_any_type(type_id)
@@ -205,12 +204,10 @@ rt_private rt_inline EIF_BOOLEAN rt_is_special_copy_semantics_item (EIF_INTEGER_
 #define eif_builtin_ISE_RUNTIME_set_pointer_field_at(field_offs,obj,offs,val)		*(EIF_POINTER *) (eif_obj_at(obj,offs) + field_offs) = (EIF_POINTER) (val)
 
 #define eif_builtin_ISE_RUNTIME_unlock_marking							eif_unlock_marking
-#define eif_builtin_ISE_RUNTIME_lock_marking							eif_lock_marking
 #define eif_builtin_ISE_RUNTIME_eif_gen_param_id(a_type_id, i)			eif_gen_param_id(a_type_id, i)
 #define eif_builtin_ISE_RUNTIME_generic_parameter_count(a_type_id)		eif_gen_count_with_dftype(eif_decoded_type(a_type_id).id)
 #define eif_builtin_ISE_RUNTIME_field_offset_of_type(i,a_type_id)		ei_offset_of_type(i,a_type_id)
 #define eif_builtin_ISE_RUNTIME_field_count_of_type(a_type_id)			ei_count_field_of_type(a_type_id)
-#define eif_builtin_ISE_RUNTIME_compiler_version						egc_compiler_tag
 
 #define eif_builtin_ISE_RUNTIME_persistent_field_count_of_type(a_type_id)	(System(To_dtype(eif_decoded_type(a_type_id).id)).cn_persistent_nbattr)
 #define eif_builtin_ISE_RUNTIME_is_field_expanded_of_type(i,a_type_id)		((System(To_dtype(eif_decoded_type(a_type_id).id)).cn_types[i - 1] & SK_HEAD) == SK_EXP)
@@ -328,7 +325,6 @@ rt_private rt_inline EIF_BOOLEAN rt_is_special_copy_semantics_item (EIF_INTEGER_
 
 
 /*REFLECTED_COPY_SEMANTICS_OBJECT class*/
-#define eif_builtin_REFLECTED_COPY_SEMANTICS_OBJECT_dereference(ptr, offset)	*(EIF_REFERENCE *) eif_obj_at(ptr, offset)
 #define eif_builtin_REFLECTED_COPY_SEMANTICS_OBJECT_object_from_address(ptr)	(EIF_REFERENCE) ptr
 
 #ifdef __cplusplus

--- a/Src/Delivery/studio/built_ins/classic/ISE_RUNTIME.e
+++ b/Src/Delivery/studio/built_ins/classic/ISE_RUNTIME.e
@@ -1,0 +1,81 @@
+class
+	ISE_RUNTIME
+
+feature -- Feature specific to ISE runtime.
+
+	generator_of_type (a_type_id: INTEGER): STRING
+			-- Name of the generating class of current object
+		external
+			"C inline use %"eif_out.h%""
+		alias
+			"return c_generator_of_type(eif_decoded_type($a_type_id));"
+		end
+
+	check_assert (b: BOOLEAN): BOOLEAN
+		external
+			"C use %"eif_copy.h%""
+		alias
+			"c_check_assert"
+		end
+
+	in_assertion: BOOLEAN
+			-- Are we currently checking some assertions?
+		external
+			"C inline use %"eif_eiffel.h%""
+		alias
+			"[
+				GTCX;	/* Needed in multithreaded mode as `in_assertion' is a per-thread data. */
+				return EIF_TEST(in_assertion!=0);
+			]"
+		end
+
+	once_objects (a_result_type_id: INTEGER): SPECIAL [ANY]
+			-- Once objects initialized in current system.
+			-- `a_result_type_id' is the dynamic type of `SPECIAL [ANY]'.
+		external
+			"C inline use %"eif_memory_analyzer.h%""
+		alias
+			"return eif_once_objects_of_result_type(eif_decoded_type($a_result_type_id));"
+		end
+
+feature -- Internal C routines
+
+	type_id_from_name (s: POINTER): INTEGER
+			-- Dynamic type whose name is represented by `s'.
+		external
+			"C signature (char *): EIF_INTEGER use %"eif_cecil.h%""
+		alias
+			"eif_type_id"
+		end
+
+	pre_ecma_mapping_status: BOOLEAN
+			-- Do we map old name to new name by default?
+		external
+			"C inline use %"eif_cecil.h%""
+		alias
+			"return eif_pre_ecma_mapping();"
+		end
+
+	set_pre_ecma_mapping (v: BOOLEAN)
+			-- Set `pre_ecma_mapping_status' with `v'.
+		external
+			"C inline use %"eif_cecil.h%""
+		alias
+			"eif_set_pre_ecma_mapping($v)"
+		end
+
+	storable_version_of_type (a_type_id: INTEGER): detachable STRING
+		external
+			"C inline use %"eif_eiffel.h%""
+		alias
+			"[
+				const char *l_version = System(To_dtype(eif_decoded_type($a_type_id).id)).cn_version;
+				if (l_version && (l_version[0] != (char) 0)) {
+					return RTMS(l_version);
+				} else {
+					return NULL;
+				}
+			]"
+		end
+	
+end	

--- a/Src/Delivery/studio/built_ins/classic/ISE_RUNTIME.e
+++ b/Src/Delivery/studio/built_ins/classic/ISE_RUNTIME.e
@@ -77,5 +77,21 @@ feature -- Internal C routines
 				}
 			]"
 		end
+
+	compiler_version: INTEGER
+		external
+			"C macro use %"eif_project.h%""
+		alias
+			"egc_compiler_tag"
+		end
+
+feature -- Object marking
+
+	lock_marking
+		external
+			"C blocking use %"eif_traverse.h%""
+		alias
+			"eif_lock_marking"
+		end
 	
 end	

--- a/Src/library/base/elks/kernel/ise_runtime.e
+++ b/Src/library/base/elks/kernel/ise_runtime.e
@@ -17,22 +17,18 @@ feature -- Feature specific to ISE runtime.
 
 	frozen generator_of_type (a_type_id: INTEGER): STRING
 			-- Name of the generating class of current object
-		external
-			"C inline use %"eif_out.h%""
-		alias
-			"return c_generator_of_type(eif_decoded_type($a_type_id));"
+ 		external
+ 			"built_in static"
 		ensure
 			instance_free: class
-		end
+ 		end
 
 	frozen check_assert (b: BOOLEAN): BOOLEAN
-		external
-			"C use %"eif_copy.h%""
-		alias
-			"c_check_assert"
+ 		external
+ 			"built_in static"
 		ensure
 			instance_free: class
-		end
+ 		end
 
  	frozen generating_type_of_type (a_type_id: INTEGER): STRING
  		external
@@ -43,49 +39,38 @@ feature -- Feature specific to ISE runtime.
 
 	frozen in_assertion: BOOLEAN
 			-- Are we currently checking some assertions?
-		external
-			"C inline use %"eif_eiffel.h%""
-		alias
-			"[
-				GTCX;	/* Needed in multithreaded mode as `in_assertion' is a per-thread data. */
-				return EIF_TEST(in_assertion!=0);
-			]"
+ 		external
+ 			"built_in static"
 		ensure
 			instance_free: class
-		end
+ 		end
 
 	frozen once_objects (a_result_type_id: INTEGER): SPECIAL [ANY]
 			-- Once objects initialized in current system.
 			-- `a_result_type_id' is the dynamic type of `SPECIAL [ANY]'.
-		external
-			"C inline use %"eif_memory_analyzer.h%""
-		alias
-			"return eif_once_objects_of_result_type(eif_decoded_type($a_result_type_id));"
+ 		external
+ 			"built_in static"
 		ensure
 			instance_free: class
-		end
+ 		end
 
 feature -- Internal C routines
 
 	frozen type_conforms_to (a_type_id_1, a_type_id_2: INTEGER): BOOLEAN
 			-- Does `a_type_id_1' conform to `a_type_id_2'?
 		external
-			"C inline use %"eif_gen_conf.h%""
-		alias
-			"return eif_gen_conf($a_type_id_1, $a_type_id_2);"
+			"built_in static"
 		ensure
 			instance_free: class
-		end
+ 		end
 
 	frozen type_id_from_name (s: POINTER): INTEGER
 			-- Dynamic type whose name is represented by `s'.
 		external
-			"C signature (char *): EIF_INTEGER use %"eif_cecil.h%""
-		alias
-			"eif_type_id"
+			"built_in static"
 		ensure
 			instance_free: class
-		end
+ 		end
 
 	frozen dynamic_type (object: separate ANY): INTEGER
 			-- Dynamic type of `object'.
@@ -98,9 +83,7 @@ feature -- Internal C routines
 	frozen pre_ecma_mapping_status: BOOLEAN
 			-- Do we map old name to new name by default?
 		external
-			"C inline use %"eif_cecil.h%""
-		alias
-			"return eif_pre_ecma_mapping();"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -108,9 +91,7 @@ feature -- Internal C routines
 	frozen set_pre_ecma_mapping (v: BOOLEAN)
 			-- Set `pre_ecma_mapping_status' with `v'.
 		external
-			"C inline use %"eif_cecil.h%""
-		alias
-			"eif_set_pre_ecma_mapping($v)"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -118,9 +99,7 @@ feature -- Internal C routines
 	frozen is_attached_type (a_type_id: INTEGER): BOOLEAN
 			-- Is `a_type' an attached type?
 		external
-			"C inline  use %"eif_gen_conf.h%""
-		alias
-			"return eif_is_attached_type($a_type_id)"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -128,9 +107,7 @@ feature -- Internal C routines
 	frozen detachable_type (a_type_id: INTEGER): INTEGER
 			-- Detachable version of `a_type'
 		external
-			"C inline  use %"eif_gen_conf.h%""
-		alias
-			"return eif_non_attached_type($a_type_id)"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -138,9 +115,7 @@ feature -- Internal C routines
 	frozen attached_type (a_type_id: INTEGER): INTEGER
 			-- Attached version of `a_type'
 		external
-			"C inline use %"eif_gen_conf.h%""
-		alias
-			"return eif_attached_type($a_type_id)"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -148,9 +123,7 @@ feature -- Internal C routines
 	frozen is_field_transient_of_type (i: INTEGER; a_type_id: INTEGER): BOOLEAN
 			-- Is `i-th' field (zero based index) a transient field?
 		external
-			"C inline use %"eif_eiffel.h%""
-		alias
-			"return EIF_IS_TRANSIENT_ATTRIBUTE(System(To_dtype(eif_decoded_type($a_type_id).id)), $i - 1);"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -158,9 +131,7 @@ feature -- Internal C routines
 	frozen is_field_expanded_of_type (i: INTEGER; a_type_id: INTEGER): BOOLEAN
 			-- Is `i'-th field of `object' an expanded attribute?
 		external
-			"C inline use %"eif_eiffel.h%""
-		alias
-			"return ((System(To_dtype(eif_decoded_type($a_type_id).id)).cn_types[$i - 1] & SK_HEAD) == SK_EXP);"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -168,34 +139,21 @@ feature -- Internal C routines
 	frozen persistent_field_count_of_type (a_type_id: INTEGER): INTEGER
 			-- Number of logical fields in dynamic type `type_id' that are not transient.
 		external
-			"C inline use %"eif_eiffel.h%""
-		alias
-			"return (System(To_dtype(eif_decoded_type($a_type_id).id)).cn_persistent_nbattr);"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
 
 	frozen storable_version_of_type (a_type_id: INTEGER): detachable STRING
 		external
-			"C inline use %"eif_eiffel.h%""
-		alias
-			"[
-				const char *l_version = System(To_dtype(eif_decoded_type($a_type_id).id)).cn_version;
-				if (l_version && (l_version[0] != (char) 0)) {
-					return RTMS(l_version);
-				} else {
-					return NULL;
-				}
-			]"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
 
 	compiler_version: INTEGER
 		external
-			"C macro use %"eif_project.h%""
-		alias
-			"egc_compiler_tag"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -245,9 +203,7 @@ feature -- Internal support
 	frozen field_count_of_type (a_type_id: INTEGER): INTEGER
 			-- Number of logical fields in dynamic type `a_type_id'.
 		external
-			"C macro signature (EIF_INTEGER): EIF_INTEGER use %"eif_internal.h%""
-		alias
-			"ei_count_field_of_type"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -255,9 +211,7 @@ feature -- Internal support
 	frozen field_offset_of_type (i: INTEGER; a_type_id: INTEGER): INTEGER
 			-- Physical offset of the `i'-th field for an object of dynamic type `a_type'.
 		external
-			"C macro use %"eif_eiffel.h%""
-		alias
-			"ei_offset_of_type"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -789,9 +743,7 @@ feature -- Internal support
 	frozen generic_parameter_count (a_type_id: INTEGER): INTEGER
 			-- Number of generic parameters for object of dynamic type `a_type_id'.
 		external
-			"C inline use %"eif_gen_conf.h%""
-		alias
-			"return eif_gen_count_with_dftype(eif_decoded_type($a_type_id).id);"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -799,9 +751,7 @@ feature -- Internal support
 	frozen eif_gen_param_id (a_type_id: INTEGER; i: INTEGER): INTEGER
 			-- Type of `i'-th generic parameter for object of dynamic type `a_type_id'.
 		external
-			"C inline use %"eif_gen_conf.h%""
-		alias
-			"return eif_gen_param_id($a_type_id, $i);"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -812,9 +762,7 @@ feature -- Object marking
 			-- Get a lock on `mark' and `unmark' routine so that 2 threads cannot `mark' and
 			-- `unmark' at the same time.
 		external
-			"C blocking use %"eif_traverse.h%""
-		alias
-			"eif_lock_marking"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -823,9 +771,7 @@ feature -- Object marking
 			-- Release a lock on `mark' and `unmark', so that another thread can
 			-- use `mark' and `unmark'.
 		external
-			"C use %"eif_traverse.h%""
-		alias
-			"eif_unlock_marking"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -852,7 +798,7 @@ feature -- Object marking
 		end
 
 note
-	copyright: "Copyright (c) 1984-2018, Eiffel Software and others"
+	copyright: "Copyright (c) 1984-2019, Eiffel Software and others"
 	license:   "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/Src/library/base/elks/support/reflected_copy_semantics_object.e
+++ b/Src/library/base/elks/support/reflected_copy_semantics_object.e
@@ -117,8 +117,8 @@ feature {REFLECTED_COPY_SEMANTICS_OBJECT} -- Access
 feature {NONE} -- Implementation
 
 	dereference (ptr: POINTER; offset: INTEGER): POINTER
-		external
-			"built_in static"
+		do
+			Result :=  {ISE_RUNTIME}.raw_reference_field_at_offset (ptr, offset)
 		end
 
 	object_from_address (ptr: POINTER): ANY

--- a/Src/library/base/elks/support/reflected_copy_semantics_object.e
+++ b/Src/library/base/elks/support/reflected_copy_semantics_object.e
@@ -118,20 +118,16 @@ feature {NONE} -- Implementation
 
 	dereference (ptr: POINTER; offset: INTEGER): POINTER
 		external
-			"C inline use %"eif_built_in.h%""
-		alias
-			"return *(EIF_REFERENCE *) eif_obj_at($ptr, $offset);"
+			"built_in static"
 		end
 
 	object_from_address (ptr: POINTER): ANY
 		external
-			"C inline use %"eif_built_in.h%""
-		alias
-			"return (EIF_REFERENCE) $ptr;"
+			"built_in static"
 		end
 
 note
-	copyright: "Copyright (c) 1984-2013, Eiffel Software and others"
+	copyright: "Copyright (c) 1984-2019, Eiffel Software and others"
 	license: "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/Src/library/base/elks/support/reflector.e
+++ b/Src/library/base/elks/support/reflector.e
@@ -212,9 +212,7 @@ feature -- Status report
 		require
 			type_id_nonnegative: type_id >= 0
 		external
-			"C signature (EIF_INTEGER): EIF_BOOLEAN use %"eif_internal.h%""
-		alias
-			"eif_special_any_type"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -226,9 +224,7 @@ feature -- Status report
 		require
 			type_id_nonnegative: type_id >= 0
 		external
-			"C signature (EIF_INTEGER): BOOLEAN use %"eif_internal.h%""
-		alias
-			"eif_is_special_type"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -238,9 +234,7 @@ feature -- Status report
 		require
 			type_id_nonnegative: type_id >= 0
 		external
-			"C signature (EIF_INTEGER): BOOLEAN use %"eif_internal.h%""
-		alias
-			"eif_is_tuple_type"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -423,9 +417,7 @@ feature -- Measurement
 		require
 			type_id_nonnegative: type_id >= 0
 		external
-			"C macro signature (EIF_INTEGER): EIF_INTEGER use %"eif_internal.h%""
-		alias
-			"ei_count_field_of_type"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -467,9 +459,7 @@ feature {NONE} -- Implementation
 			-- `type_id' cannot represent a SPECIAL type, use
 			-- `new_special_any_instance' instead.	
 		external
-			"C inline use %"eif_macros.h%""
-		alias
-			"return RTLNSMART(eif_decoded_type($type_id).id);"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -479,9 +469,7 @@ feature {NONE} -- Implementation
 			-- Note: returned object is not initialized and may
 			-- hence violate its invariant.
 		external
-			"C inline use %"eif_macros.h%""
-		alias
-			"return RTLNT(eif_decoded_type($type_id).id);"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -489,9 +477,7 @@ feature {NONE} -- Implementation
 	c_new_type_instance_of (type_id: INTEGER): TYPE [detachable ANY]
 			-- New instance of TYPE for object of type `type_id'.
 		external
-			"C inline use %"eif_macros.h%""
-		alias
-			"return eif_type_malloc(eif_decoded_type($type_id), 0);"
+			"built_in static"
 		ensure
 			instance_free: class
 		end
@@ -505,7 +491,7 @@ feature {NONE} -- Implementation
 		end
 
 note
-	copyright: "Copyright (c) 1984-2018, Eiffel Software and others"
+	copyright: "Copyright (c) 1984-2019, Eiffel Software and others"
 	license:   "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software


### PR DESCRIPTION
…COPY_SEMANTICS_OBJECT`

which are implemented with external C to use built-in routines.