### PR TITLE
Diagram tool cancel export to PNG fix

### DIFF
--- a/Src/Eiffel/interface/new_graphical/commands/eb_diagram_to_ps_command.e
+++ b/Src/Eiffel/interface/new_graphical/commands/eb_diagram_to_ps_command.e
@@ -73,7 +73,7 @@ feature -- Basic operations
 					end
 					dial.set_full_file_path (l_path)
 					dial.show_modal_to_window (tool.develop_window.window)
-					if not dial.full_file_path.is_empty then
+					if not dial.full_file_path.is_empty and then not dial.selected_button_name.same_string ((create {EV_DIALOG_NAMES}).ev_cancel) then
 						error := 1
 						p := tool.projector.world_as_pixmap (5)
 						if p /= Void then
@@ -138,7 +138,7 @@ feature -- Basic operations
 			-- preferences.
 
 note
-	copyright:	"Copyright (c) 1984-2020, Eiffel Software"
+	copyright:	"Copyright (c) 1984-2024, Eiffel Software"
 	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options:	"http://www.eiffel.com/licensing"
 	copying: "[


### PR DESCRIPTION
Short description: Fixing unexpected behavior when cancelling the export of a diagram to PNG.

Long description:
I noticed in EiffelStudio 23.09 when I cancel the file selection dialog for exporting a diagram to PNG I get an error message saying "Could not save diagram to TESTROOT.png" (with TESTROOT being the cluster in the diagram) and no file is created.

The strange thing is that when I debug EiffelStudio (built from the sources in this repo) I don't get the error message, but instead the diagram is saved as a PNG file anyway (I did click "Cancel")! Maybe there's something wrong with my debug version of EiffelStudio or something changed in the sources in the last year.

And if something changed in the code in the meantime: Why do I get the error message?

In the save dialog for saving a copy of a class I don't get an error message when I click "Cancel" and this is what I expect...

In both versions I can successfully save the diagram to PNG if I click "Save" in the file selection dialog.
But if the file exists, there should be a prompt if the file should be overwritten, don't you think so? But this should be consistent throughout EiffelStudio and I don't know yet how other save operations behave...

About the fix:
This is just a quick fix. I would prefer to use save_actions of the file selection dialog but I didn't want to do a larger refactoring in case the sources changed and you refuse this pull request.

Let me know what you think.
