### PR TITLE
Delete saved layout fix

### DIFF
--- a/Src/Eiffel/interface/new_graphical/managers/eb_named_layout_manager.e
+++ b/Src/Eiffel/interface/new_graphical/managers/eb_named_layout_manager.e
@@ -123,9 +123,9 @@ feature -- Command
 				l_item := layouts.item (a_name.as_string_32)
 				if l_item /= Void then
 					create l_file.make_with_path (l_item.file_path)
-					l_file.open_read_write
-
-					l_file.delete
+					if l_file.exists then
+						l_file.delete
+					end
 					layouts.remove (a_name.as_string_32)
 
 					Result := True
@@ -261,7 +261,7 @@ invariant
 	not_void: layouts /= Void
 
 note
-	copyright: "Copyright (c) 1984-2012, Eiffel Software"
+	copyright: "Copyright (c) 1984-2024, Eiffel Software"
 	license:   "GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options: "http://www.eiffel.com/licensing"
 	copying: "[


### PR DESCRIPTION
Fixed: Error message on delete saved layout that occurred (at least) on Windows platform.

See also: https://groups.google.com/g/eiffel-users/c/hVQsF874K1I

I got an error message saying "Can’t delete selected item" when I tried to delete a previously saved (tools) layout and the layout file was not deleted. But this error message only came up on Windows. On Ubuntu Linux the layout file was successfully deleted.

So I changed the code similarly to how file deletions are done in most other EiffelStudio code (make_with_path, existence check and then delete without opening the file).