### PR TITLE
Diagram tool links fix

### DIFF
--- a/Src/Eiffel/interface/new_graphical/case_tool/eiffel_studio/es_graph.e
+++ b/Src/Eiffel/interface/new_graphical/case_tool/eiffel_studio/es_graph.e
@@ -60,10 +60,10 @@ feature -- Access
 			-- Container of `Current'.
 			-- Used to access surface on which `Current' is displayed.
 
-	class_of_id (a_id: STRING): ES_CLASS
-			-- Class of `a_id'
+	class_of_name (a_name: STRING): ES_CLASS
+			-- Class of `a_name'
 		require
-			a_id_not_void: a_id /= Void
+			a_name_not_void: a_name /= Void
 		local
 			l_nodes: like nodes
 			l_class: ES_CLASS
@@ -75,7 +75,7 @@ feature -- Access
 				l_nodes.after or Result /= Void
 			loop
 				l_class ?= l_nodes.item
-				if l_class /= Void and then l_class.es_class_id.is_equal (a_id) then
+				if l_class /= Void and then l_class.name.is_equal (a_name) then
 					Result := l_class
 				end
 				l_nodes.forth
@@ -960,7 +960,7 @@ invariant
 	client_supplier_links_lookup_not_void: client_supplier_links_lookup /= Void
 
 note
-	copyright:	"Copyright (c) 1984-2020, Eiffel Software"
+	copyright:	"Copyright (c) 1984-2024, Eiffel Software"
 	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options:	"http://www.eiffel.com/licensing"
 	copying: "[

--- a/Src/Eiffel/interface/new_graphical/case_tool/eiffel_view/eiffel_factory.e
+++ b/Src/Eiffel/interface/new_graphical/case_tool/eiffel_view/eiffel_factory.e
@@ -113,8 +113,8 @@ feature -- Access
 				if source_name /= Void then
 					target_name := node.attribute_by_name (target_string).value
 					if target_name /= Void then
-						source := l_world.model.class_of_id (source_name)
-						target := l_world.model.class_of_id (target_name)
+						source := l_world.model.class_of_name (source_name)
+						target := l_world.model.class_of_name (target_name)
 						if source /= Void and target /= Void then
 							if node_name.same_string (xml_client_supplier_figure_node_name) then
 								if source.has_supplier (target) then
@@ -207,7 +207,7 @@ feature {NONE} -- Constants
 		-- Xml string constants
 
 note
-	copyright:	"Copyright (c) 1984-2020, Eiffel Software"
+	copyright:	"Copyright (c) 1984-2024, Eiffel Software"
 	license:	"GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options:	"http://www.eiffel.com/licensing"
 	copying: "[


### PR DESCRIPTION
Fixed: Inheritance and supplier links in the diagram tool get lost after retrieval from diagram XML files. Therefore they are not displayed and saved to diagram XML files anymore.

See also: https://groups.google.com/g/eiffel-users/c/bBJKGkAOXf0

Steps to reproduce (this should work with any project that includes more that one class and with at least one inheritance or supplier relation between the classes within one project's cluster, I describe it here with the project I tested it with):

- Open project in EiffelStudio installation folder: examples/studio/tour (you might want to copy this folder to another location...)
- Delete folder EIFGENs/classic/Diagrams if the project was already compiled and you used the diagram tool with it
- Open and compile the project in EiffelStudio
- Make sure link context tool is active (View -> Link Context Tool)
- In Browse tool click on class INVALID in cluster root_cluster
- Open Diagram tool, Disable Auto Hide, make sure inheritance and supplier links are not hidden (there are two toolbar buttons for it) -> one bubble for class INVALID is displayed
- In Browse tool click on cluster root_cluster -> four bubbles for the classes in the project are display and one inheritance link and one supplier link are displayed
- In Browse tool click on class INVALID in cluster root_cluster again -> again the one bubble for INVALID
- In Browse tool click on cluster root_cluster again -> No links displayed this time!!!
- Click toolbar button "Include all classes of cluster" and move mouse into diagram view -> links displayed again (just when you moved the mouse into the view)

Notes:

In addition to my eiffel-users post I was able to reproduce this issue also with EiffelStudio 23.09 on Linux.

The old code compared the source and target class names of the links in the XML files with the class ids in the model. This obviously always fails and thus the links are not displayed (and stored later).

I tested this fix and it works in my environment, but:

I'm not really sure about what caused this issue but I'm pretty sure it was some kind of code change which introduced this regression because I assume this once worked.
The introduction of the call of class_by_id in EIFFEL_FACTORY was in 2006 with commit a022fd4 but I find it strange that this issue hasn't been reported for like 18 years. So maybe something else caused it?

Also: The XML for the link elements only contains the source and target class names. I don't know if checking only the class name is always sufficient. It seems that in other places in EiffelStudio check are done either for the class id or the cluster and class name.