### PR TITLE
AutoTest tests tree fix

### DIFF
--- a/Src/framework/testing/etest/retrieval/etest_class_synchronizer.e
+++ b/Src/framework/testing/etest/retrieval/etest_class_synchronizer.e
@@ -374,8 +374,13 @@ feature {NONE} -- Implementation: tags
 			check l_test_class /= Void end
 
 			if project_access.is_initialized then
-				l_class := l_test_class.eiffel_class
-				l_group := l_class.cluster
+				if a_tag.starts_with ("covers/") then
+	 				if attached {EIFFEL_CLASS_I} project_access.class_from_name (a_class_name, Void) as l_ec then
+	 					l_class := l_ec
+	 				end
+				else
+					l_class := l_test_class.eiffel_class
+				end
 			end
 
 			if l_class /= Void then
@@ -637,7 +642,7 @@ invariant
 		attached old_test_map implies attached test_class
 
 note
-	copyright: "Copyright (c) 1984-2021, Eiffel Software"
+	copyright: "Copyright (c) 1984-2025, Eiffel Software"
 	license: "GPL version 2 (see http://www.eiffel.com/licensing/gpl.txt)"
 	licensing_options: "http://www.eiffel.com/licensing"
 	copying: "[


### PR DESCRIPTION
Short description:
Classes under test (node "covers") in the tests tree were displayed with the cluster hierarchy of the test classes instead of the cluster hierarchy of the classes under test. This is now fixed.

Long description:
This is a fix for my problem report at: https://support.eiffel.com/report_detail/19912

The change that leads to the wrong display of the classes under test in the tree was done with commit https://github.com/EiffelSoftware/EiffelStudio/commit/36028aea0429eea5befa70c7589d50bcf4026bac in class ETEST_CLASS_SYNCHRONIZER, feature add_class_path.

This change leads to the following values of a_tag computed in add_class_path for the two classes TEST_BANK_ACCOUNT and BANK_ACCOUNT (see https://www.eiffel.org/doc/eiffelstudio/The_AutoTest_Interface):

1. "class/cluster:accounts/cluster:tests/class:TEST_BANK_ACCOUNT" (correct)
2. "covers/cluster:accounts/cluster:tests/class:BANK_ACCOUNT/feature:deposit" (wrong cluster hierarchy)

My fix changes the computation of a_tag only for tags starting with "covers/" (classes under test). In this case the class object is retrieved by the given class name (instead of using the test class object) without the group/cluster. l_group is not needed here because the class under test is usually not in the test class cluster.

Now these are the values of a_tag:

1. "class/cluster:accounts/cluster:tests/class:TEST_BANK_ACCOUNT" (unchanged)
2. "covers/cluster:accounts/class:BANK_ACCOUNT/feature:deposit" (correct cluster hierarchy)

Please review and let me know what you think.